### PR TITLE
fix(ci): remove pr-title check trigger when merge to main

### DIFF
--- a/.github/workflows/pull-request-title-validation.yml
+++ b/.github/workflows/pull-request-title-validation.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
 
 jobs:
   pr-title-check:


### PR DESCRIPTION
# Description
Fix PR title validation get triggered when merge to main

Fixes https://github.com/benbenbang/types-confluent-kafka/issues/3