### PR TITLE
refactor: replace semantic release method by gh-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   release:
     name: release
-    if: startsWith(github.event.head_commit.message, 'build(release)')
+    if: startsWith(github.event.head_commit.message, 'build(release)') && contains(${{ ['OWNER', 'CONTRIBUTOR'], github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     permissions:
       contents: write # to be able to publish a GitHub release

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# This is the CODEOWNER FILES for types-confluent-kafka
+# Feel free to use it, if you want to use it in your repo
+# The documentation can be found here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+# Notes:
+# - Order is important; the last matching pattern takes the most precedence.
+# - You can also use email addresses if you prefer. They'll be used to look up users just like we do for commit author emails.
+# - Teams can be specified as code owners as well. Teams should be identified in the format @org/team-name.
+
+# @benbenbang (me) will be requested for review when someone opens a pull request.
+.github/*           @benbenbang
+CODEOWNERS          @benbenbang
+.releaserc.json     @benbenbang
+LICENSE             @benbenbang


### PR DESCRIPTION
# Description
In order to use github way to do semantic version
we will need to 
- well define the labels, the cli checks the labels instead of the commit message
- prepare `.github/release.yml` to define how the release should work
- [optional] prepare `CODEOWNERS` file


Resolve #53 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new typings)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
