### PR TITLE
ci: exclude development label in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,6 +5,7 @@ changelog:
       - ignore-for-release
       - wip
       - draft
+      - development
     authors:
       - octocat
       - ptah-lgtm


### PR DESCRIPTION
remove `development` from release note if it's triggered by `gh`