### PR TITLE
refactor: clean up string type py2 compat

### DIFF
--- a/confluent_kafka-stubs/_util/validation_util.pyi
+++ b/confluent_kafka-stubs/_util/validation_util.pyi
@@ -5,11 +5,6 @@ This package is licensed under the Apache 2.0 License.
 
 from ..cimpl import KafkaError as KafkaError
 
-try:
-    string_type = basestring  # type: ignore
-except NameError:
-    string_type = str
-
 class ValidationUtil:
     @staticmethod
     def check_multiple_not_none(obj, vars_to_check) -> None: ...

--- a/confluent_kafka-stubs/admin/__init__.pyi
+++ b/confluent_kafka-stubs/admin/__init__.pyi
@@ -55,11 +55,6 @@ from ._scram import UserScramCredentialDeletion as UserScramCredentialDeletion
 from ._scram import UserScramCredentialsDescription as UserScramCredentialsDescription
 from ._scram import UserScramCredentialUpsertion as UserScramCredentialUpsertion
 
-try:
-    string_type = basestring  # type: ignore
-except NameError:
-    string_type = str
-
 class AdminClient(_AdminClientImpl):
     def __init__(self, conf: dict[str, Any]) -> None: ...
     def create_topics(

--- a/confluent_kafka-stubs/admin/_acl.pyi
+++ b/confluent_kafka-stubs/admin/_acl.pyi
@@ -13,11 +13,6 @@ from .._util import ValidationUtil as ValidationUtil
 from ._resource import ResourcePatternType as ResourcePatternType
 from ._resource import ResourceType as ResourceType
 
-try:
-    string_type = basestring  # type: ignore
-except NameError:
-    string_type = str
-
 class AclOperation(Enum):
     UNKNOWN: Literal["ACL_OPERATION_UNKNOWN"]
     ANY: Literal["ACL_OPERATION_ANY"]

--- a/confluent_kafka-stubs/avro/cached_schema_registry_client.pyi
+++ b/confluent_kafka-stubs/avro/cached_schema_registry_client.pyi
@@ -10,11 +10,6 @@ from typing import TYPE_CHECKING, DefaultDict, Literal
 from .error import ClientError as ClientError
 from .load import loads as loads
 
-try:
-    string_type = basestring  # type: ignore
-except:
-    string_type = str
-
 if TYPE_CHECKING:
     """Helping users who installed avro package can get type hints"""
     try:


### PR DESCRIPTION
### **Description:**
since python constraints to `>= 3.8`, no need to backward compat


### **Related Issue:**
resolve #110 

### **Type of change**:
- [x] New feature / Refactor / Enhancement (non-breaking change which adds new typings)

### **Checklist:**

- [ ] All code follows the project's coding style and conventions.
- [ ] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings or errors.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding updates to the documentation.
