### PR TITLE
refactor: use relative import from `this` typing package

### DIFF
--- a/confluent_kafka-stubs/admin/__init__.pyi
+++ b/confluent_kafka-stubs/admin/__init__.pyi
@@ -8,10 +8,7 @@ from __future__ import annotations
 from asyncio import Future
 from typing import Any
 
-# pypi/conda library
-from confluent_kafka._model import ConsumerGroupTopicPartitions
-
-from .._model import ConsumerGroupState
+from .._model import ConsumerGroupState, ConsumerGroupTopicPartitions
 from ..cimpl import CONFIG_SOURCE_DEFAULT_CONFIG as CONFIG_SOURCE_DEFAULT_CONFIG
 from ..cimpl import CONFIG_SOURCE_DYNAMIC_BROKER_CONFIG as CONFIG_SOURCE_DYNAMIC_BROKER_CONFIG
 from ..cimpl import CONFIG_SOURCE_DYNAMIC_DEFAULT_BROKER_CONFIG as CONFIG_SOURCE_DYNAMIC_DEFAULT_BROKER_CONFIG

--- a/confluent_kafka-stubs/avro/__init__.pyi
+++ b/confluent_kafka-stubs/avro/__init__.pyi
@@ -6,20 +6,19 @@ This package is licensed under the Apache 2.0 License.
 # This module is going to be deprecated
 
 # standard library
-from typing import Any, Callable, overload
+from typing import Any, Callable
 
-# pypi/conda library
-from confluent_kafka import Consumer as Consumer
-from confluent_kafka import Producer as Producer
-from confluent_kafka.avro.cached_schema_registry_client import CachedSchemaRegistryClient as CachedSchemaRegistryClient
-from confluent_kafka.avro.error import ClientError as ClientError
-from confluent_kafka.avro.load import load as load
-from confluent_kafka.avro.load import loads as loads
-from confluent_kafka.avro.serializer import KeySerializerError as KeySerializerError
-from confluent_kafka.avro.serializer import SerializerError as SerializerError
-from confluent_kafka.avro.serializer import ValueSerializerError as ValueSerializerError
-from confluent_kafka.avro.serializer.message_serializer import MessageSerializer as MessageSerializer
-from confluent_kafka.cimpl import Message
+from ..avro.cached_schema_registry_client import CachedSchemaRegistryClient as CachedSchemaRegistryClient
+from ..avro.error import ClientError as ClientError
+from ..avro.load import load as load
+from ..avro.load import loads as loads
+from ..avro.serializer import KeySerializerError as KeySerializerError
+from ..avro.serializer import SerializerError as SerializerError
+from ..avro.serializer import ValueSerializerError as ValueSerializerError
+from ..avro.serializer.message_serializer import MessageSerializer as MessageSerializer
+from ..cimpl import Consumer as Consumer
+from ..cimpl import Message
+from ..cimpl import Producer as Producer
 
 class AvroProducer(Producer):
     def __init__(

--- a/confluent_kafka-stubs/avro/error.pyi
+++ b/confluent_kafka-stubs/avro/error.pyi
@@ -7,8 +7,7 @@ from __future__ import annotations
 # standard library
 from typing import ClassVar
 
-# pypi/conda library
-from confluent_kafka.cimpl import Message
+from ..cimpl import Message
 
 class ClientError(Exception):
     """Error thrown by Schema Registry clients"""

--- a/confluent_kafka-stubs/avro/load.pyi
+++ b/confluent_kafka-stubs/avro/load.pyi
@@ -8,8 +8,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-# pypi/conda library
-from confluent_kafka.avro.error import ClientError as ClientError
+from ..avro.error import ClientError as ClientError
 
 if TYPE_CHECKING:
     """Helping users who installed avro package can get type hints"""

--- a/confluent_kafka-stubs/avro/serializer/message_serializer.pyi
+++ b/confluent_kafka-stubs/avro/serializer/message_serializer.pyi
@@ -9,12 +9,11 @@ from io import BytesIO
 from logging import Logger
 from typing import TYPE_CHECKING, Any, Callable
 
-# pypi/conda library
-from confluent_kafka.avro import ClientError as ClientError
-from confluent_kafka.avro.serializer import KeySerializerError as KeySerializerError
-from confluent_kafka.avro.serializer import SerializerError as SerializerError
-from confluent_kafka.avro.serializer import ValueSerializerError as ValueSerializerError
-from confluent_kafka.schema_registry.schema_registry_client import SchemaRegistryClient
+from ...schema_registry.schema_registry_client import SchemaRegistryClient
+from .. import ClientError as ClientError
+from . import KeySerializerError as KeySerializerError
+from . import SerializerError as SerializerError
+from . import ValueSerializerError as ValueSerializerError
 
 log: Logger
 MAGIC_BYTE: int

--- a/confluent_kafka-stubs/error.pyi
+++ b/confluent_kafka-stubs/error.pyi
@@ -7,14 +7,10 @@ from __future__ import annotations
 # standard library
 from typing import ClassVar
 
-# pypi/conda library
-from confluent_kafka.cimpl import KafkaError as KafkaError
-from confluent_kafka.cimpl import KafkaException as KafkaException
-from confluent_kafka.serialization import SerializationError as SerializationError
-
 from .cimpl import KafkaError as KafkaError
 from .cimpl import KafkaException as KafkaException
 from .cimpl import Message
+from .serialization import SerializationError as SerializationError
 
 class _KafkaClientError(KafkaException):
     """

--- a/confluent_kafka-stubs/serialization/__init__.pyi
+++ b/confluent_kafka-stubs/serialization/__init__.pyi
@@ -7,8 +7,7 @@ from __future__ import annotations
 # standard library
 from typing import ClassVar
 
-# pypi/conda library
-from confluent_kafka.error import KafkaException
+from ..error import KafkaException
 
 class MessageField:
     NONE: str


### PR DESCRIPTION
### **Description:**
replace some import ref from using `confluent_kafka` directly


### **Related Issue:**
resolve #125 

### **Type of change**:
- [x] New feature / Refactor / Enhancement (non-breaking change which adds new typings)

### **Checklist:**

- [ ] All code follows the project's coding style and conventions.
- [ ] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings or errors.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding updates to the documentation.
