### PR TITLE
fix: Correct to/from dict callables for Avro serializers

### DIFF
--- a/confluent_kafka-stubs/schema_registry/avro.pyi
+++ b/confluent_kafka-stubs/schema_registry/avro.pyi
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 # standard library
 from io import BytesIO
-from typing import Callable
+from typing import Any, Callable
 
 from ..serialization import Deserializer as Deserializer
 from ..serialization import SerializationContext
@@ -25,7 +25,7 @@ class AvroSerializer(Serializer):
         self,
         schema_registry_client: SchemaRegistryClient,
         schema_str: str | Schema,
-        to_dict: Callable[[object], SerializationContext] | None = None,
+        to_dict: Callable[[object, SerializationContext], dict[Any, Any]] | None = None,
         conf: dict | None = None,
     ) -> None: ...
     def __call__(self, obj: object, ctx: SerializationContext) -> None: ...  # type: ignore # issue: https://github.com/confluentinc/confluent-kafka-python/issues/1631
@@ -35,7 +35,7 @@ class AvroDeserializer(Deserializer):
         self,
         schema_registry_client: SchemaRegistryClient,
         schema_str: str | Schema | None = None,
-        from_dict: Callable[[dict], SerializationContext] | None = None,
+        from_dict: Callable[[dict[Any, Any], SerializationContext], object] | None = None,
         return_record_name: bool = False,
     ) -> None: ...
     def __call__(self, data: bytes, ctx: SerializationContext) -> None: ...  # type: ignore # issue: https://github.com/confluentinc/confluent-kafka-python/issues/1631


### PR DESCRIPTION
### **Description:**

Corrects the `to_dict`/`from_dict` Callable signatures for Avro serialization.

### **Related Issue:**

https://github.com/benbenbang/types-confluent-kafka/issues/154

### **Type of change**:

Please delete options that are not relevant.

- [ ] New feature / Refactor / Enhancement (non-breaking change which adds new typings)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (Updating or adding documentation, docstrings, etc.)
- [ ] Other minor changes (workflow, GitHub configs, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


### **Checklist:**

- [X] All code follows the project's coding style and conventions.
- [X] I have performed a self-review of my own code.
- [X] My changes generate no new warnings or errors.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding updates to the documentation.
