### PR TITLE
fix: Fix admin-related type stubs

### DIFF
--- a/confluent_kafka-stubs/admin/__init__.pyi
+++ b/confluent_kafka-stubs/admin/__init__.pyi
@@ -2,6 +2,7 @@
 types-confluent-kafka: A package providing type hints for the confluent-kafka Python package.
 This package is licensed under the Apache 2.0 License.
 """
+
 from __future__ import annotations
 
 # standard library
@@ -54,67 +55,100 @@ from ._scram import UserScramCredentialUpsertion as UserScramCredentialUpsertion
 
 class AdminClient(_AdminClientImpl):
     def __init__(self, conf: dict[str, Any]) -> None: ...
-    def create_topics(
+    def create_topics(  # type: ignore[reportIncompatibleMethodOverride]
         self,
         new_topics: list["NewTopic"],
         operation_timeout: float = 0,
         request_timeout: float = 1000.0,
         validate_only: bool = False,
     ) -> dict[str, "Future[NewTopic | None]"]: ...
-    def delete_topics(
-        self, topics: list[str], operation_timeout: float = 0, request_timeout: float = 1000.0
+    def delete_topics(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+        topics: list[str],
+        operation_timeout: float = 0,
+        request_timeout: float = 1000.0,
     ) -> dict[str, "Future[NewTopic | None]"]: ...
-    def list_topics(self, topic: str | None = None, timeout: float = -1) -> "ClusterMetadata": ...
+    def list_topics(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+        topic: str | None = None,
+        timeout: float = -1,
+    ) -> "ClusterMetadata": ...
     def list_groups(self, *args, **kwargs) -> "ListConsumerGroupsResult | None": ...
-    def create_partitions(
-        self, new_partitions: list["NewPartitions"], operation_timeout: float = 0, request_timeout: float = 1000.0
+    def create_partitions(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+        new_partitions: list["NewPartitions"],
+        operation_timeout: float = 0,
+        request_timeout: float = 1000.0,
+        validate_only: bool = False,
     ) -> dict[str, "Future[NewTopic | None]"]: ...
-    def describe_configs(
-        self, resources: list["ConfigResource"], request_timeout: float = 1000.0
+    def describe_configs(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+        resources: list["ConfigResource"],
+        request_timeout: float = 1000.0,
     ) -> dict["ConfigResource", "Future[dict[str, ConfigEntry]]"]: ...
-    def alter_configs(
-        self, resources: list["ConfigResource"], request_timeout: float = 1000.0, validate_only: bool = False
+    def alter_configs(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+        resources: list["ConfigResource"],
+        request_timeout: float = 1000.0,
+        validate_only: bool = False,
     ) -> dict["ConfigResource", "Future[None | KafkaException]"]: ...
-    def incremental_alter_configs(
+    def incremental_alter_configs(  # type: ignore[reportIncompatibleMethodOverride]
         self,
         resources: list["ConfigResource"],
         request_timeout: float = 1000.0,
         validate_only: bool = False,
         broker: int = 0,
     ) -> dict["ConfigResource", "Future[None | KafkaException]"]: ...
-    def create_acls(
-        self, acls: list["AclBinding"], request_timeout: float = 1000.0, **kwargs
+    def create_acls(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+        acls: list["AclBinding"],
+        request_timeout: float = 1000.0,
     ) -> dict["AclBinding", "Future[None | KafkaException]"]: ...
-    def describe_acls(
-        self, acl_binding_filter: "AclBindingFilter", request_timeout: float = 1000.0
+    def describe_acls(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+        acl_binding_filter: "AclBindingFilter",
+        request_timeout: float = 1000.0,
     ) -> "Future[list[AclBinding]]": ...
-    def delete_acls(
-        self, acl_binding_filters: list["AclBindingFilter"], request_timeout: float = 1000.0
+    def delete_acls(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+        acl_binding_filters: list["AclBindingFilter"],
+        request_timeout: float = 1000.0,
     ) -> dict["AclBindingFilter", "Future[dict[AclBindingFilter, list[AclBinding]]]"]: ...
-    def list_consumer_groups(
-        self, request_timeout: float = 1000.0, states: set["ConsumerGroupState"] | None = None
+    def list_consumer_groups(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+        request_timeout: float = 1000.0,
+        states: set["ConsumerGroupState"] | None = None,
     ) -> "Future[ListConsumerGroupsResult]": ...
-    def describe_consumer_groups(
-        self, group_ids: list[str], request_timeout: float = 1000.0
-    ) -> dict[str, "Future[dict[str, ConsumerGroupDescription]]"]: ...
-    def delete_consumer_groups(
-        self, group_ids: list[str], request_timeout: float = 1000.0
+    def describe_consumer_groups(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+        group_ids: list[str],
+        request_timeout: float = 1000.0,
+        include_authorized_operations: bool = False,
+    ) -> dict[str, "Future[ConsumerGroupDescription]"]: ...
+    def delete_consumer_groups(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+        group_ids: list[str],
+        request_timeout: float = 1000.0,
     ) -> dict[str, "Future[None]"]: ...
-    def list_consumer_group_offsets(
+    def list_consumer_group_offsets(  # type: ignore[reportIncompatibleMethodOverride]
         self,
         list_consumer_group_offsets_request: list["ConsumerGroupTopicPartitions"],
         require_stable: bool = False,
         request_timeout: float = 1000.0,
     ) -> dict[str, "Future[ConsumerGroupTopicPartitions]"]: ...
-    def alter_consumer_group_offsets(
+    def alter_consumer_group_offsets(  # type: ignore[reportIncompatibleMethodOverride]
         self,
         alter_consumer_group_offsets_request: list["ConsumerGroupTopicPartitions"],
         request_timeout: float = 1000.0,
     ) -> dict[str, "Future[ConsumerGroupTopicPartitions]"]: ...
     def set_sasl_credentials(self, username: str, password: str) -> None: ...
-    def describe_user_scram_credentials(
-        self, users: list[str], request_timeout: float = 1000.0
+    def describe_user_scram_credentials(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+        users: list[str],
+        request_timeout: float = 1000.0,
     ) -> dict[str, "Future[UserScramCredentialsDescription | KafkaException]"]: ...
-    def alter_user_scram_credentials(
-        self, alterations: list["UserScramCredentialAlteration"], request_timeout: float = 1000.0
-    ) -> dict[str, "Future[None | KafkaException]"]: ...
+    def alter_user_scram_credentials(  # type: ignore[reportIncompatibleMethodOverride]
+        self,
+        alterations: list["UserScramCredentialAlteration"],
+        request_timeout: float = 1000.0,
+    ) -> dict[str, "Future[None]"]: ...

--- a/confluent_kafka-stubs/admin/_acl.pyi
+++ b/confluent_kafka-stubs/admin/_acl.pyi
@@ -2,6 +2,7 @@
 types-confluent-kafka: A package providing type hints for the confluent-kafka Python package.
 This package is licensed under the Apache 2.0 License.
 """
+
 from __future__ import annotations
 
 # standard library
@@ -53,13 +54,13 @@ class AclBinding:
 
     def __init__(
         self,
-        restype: ResourceType,
+        restype: int | str | ResourceType,
         name: str,
-        resource_pattern_type: ResourcePatternType,
+        resource_pattern_type: int | str | ResourcePatternType,
         principal: str,
         host: str,
-        operation: AclOperation,
-        permission_type: AclPermissionType,
+        operation: int | str | AclOperation,
+        permission_type: int | str | AclPermissionType,
     ) -> None: ...
     def _convert_enums(self) -> None: ...
     def _check_forbidden_enums(self, forbidden_enums: "EnumMeta") -> None: ...

--- a/confluent_kafka-stubs/admin/_group.pyi
+++ b/confluent_kafka-stubs/admin/_group.pyi
@@ -2,32 +2,31 @@
 types-confluent-kafka: A package providing type hints for the confluent-kafka Python package.
 This package is licensed under the Apache 2.0 License.
 """
-from __future__ import annotations
 
-# standard library
-from typing import ClassVar
+from __future__ import annotations
 
 from .._model import ConsumerGroupState as ConsumerGroupState
 from .._model import Node as Node
 from .._util import ConversionUtil as ConversionUtil
 from ..cimpl import TopicPartition as TopicPartition
 from ..error import KafkaException as KafkaException
+from ._acl import AclOperation as AclOperation
 
 class ConsumerGroupListing:
-    group_id: ClassVar[str]
-    is_simple_consumer_group: ClassVar[bool]
-    state: ClassVar[ConsumerGroupState]
+    group_id: str
+    is_simple_consumer_group: bool
+    state: ConsumerGroupState
 
     def __init__(
         self,
         group_id: str,
         is_simple_consumer_group: bool,
-        state: ConsumerGroupState | None = None,
+        state: int | str | ConsumerGroupState | None = None,
     ) -> None: ...
 
 class ListConsumerGroupsResult:
-    valid: ClassVar[list[ConsumerGroupListing]]
-    errors: ClassVar[list[KafkaException]]
+    valid: list[ConsumerGroupListing]
+    errors: list[KafkaException]
 
     def __init__(
         self,
@@ -36,16 +35,16 @@ class ListConsumerGroupsResult:
     ) -> None: ...
 
 class MemberAssignment:
-    topic_partitions: ClassVar[list[TopicPartition]]
+    topic_partitions: list[TopicPartition]
 
     def __init__(self, topic_partitions: list[TopicPartition] | None = None) -> None: ...
 
 class MemberDescription:
-    member_id: ClassVar[str]
-    client_id: ClassVar[str]
-    host: ClassVar[str]
-    assignment: ClassVar[MemberAssignment]
-    group_instance_id: ClassVar[str]
+    member_id: str
+    client_id: str
+    host: str
+    assignment: MemberAssignment
+    group_instance_id: str
 
     def __init__(
         self,
@@ -57,12 +56,13 @@ class MemberDescription:
     ) -> None: ...
 
 class ConsumerGroupDescription:
-    group_id: ClassVar[str]
-    is_simple_consumer_group: ClassVar[bool]
-    members: ClassVar[list[MemberDescription]]
-    partition_assignor: ClassVar[str]
-    state: ClassVar[ConsumerGroupState]
-    coordinator: ClassVar[Node]
+    group_id: str
+    is_simple_consumer_group: bool
+    members: list[MemberDescription]
+    partition_assignor: str
+    state: ConsumerGroupState
+    coordinator: Node
+    authorized_operations: list[AclOperation]
 
     def __init__(
         self,
@@ -70,6 +70,7 @@ class ConsumerGroupDescription:
         is_simple_consumer_group: bool,
         members: list[MemberDescription],
         partition_assignor: str,
-        state: ConsumerGroupState,
+        state: int | str | ConsumerGroupState,
         coordinator: Node,
+        authorized_operations: list[int | str | AclOperation],
     ) -> None: ...


### PR DESCRIPTION
### **Description:**

Reviewed and corrected admin-related type stubs.


### **Related Issue:**

If this pull request is related to an issue, please link it here.

### **Type of change**:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


### **Additional Details:**

Categories of fixes:
  1. Incompatible method overrides between derived Python class and base C class implementations.
  2. Missing arguments / attributes or incorrect types
  3. Constructor arguments for enum types can be passed as integers, strings, or enum instances (resolved by `ConversionUtil.convert_to_enum`)
 
May overlap with `ClassVar` removal PR for `confluent_kafka-stubs/admin/_group.pyi`, but I will resolve any merge conflicts based on which PR is merged first.

### **Checklist:**

- [x] All code follows the project's coding style and conventions.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or errors.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding updates to the documentation.
