### PR TITLE
fix: add missing bool to AdminClient create_partitions method

### DIFF
--- a/confluent_kafka-stubs/admin/__init__.pyi
+++ b/confluent_kafka-stubs/admin/__init__.pyi
@@ -67,7 +67,8 @@ class AdminClient(_AdminClientImpl):
     def list_topics(self, topic: str | None = None, timeout: float = -1) -> "ClusterMetadata": ...
     def list_groups(self, *args, **kwargs) -> "ListConsumerGroupsResult | None": ...
     def create_partitions(
-        self, new_partitions: list["NewPartitions"], operation_timeout: float = 0, request_timeout: float = 1000.0
+        self, new_partitions: list["NewPartitions"], operation_timeout: float = 0, request_timeout: float = 1000.0,
+        validate_only: bool = False,
     ) -> dict[str, "Future[NewTopic | None]"]: ...
     def describe_configs(
         self, resources: list["ConfigResource"], request_timeout: float = 1000.0

--- a/confluent_kafka-stubs/admin/__init__.pyi
+++ b/confluent_kafka-stubs/admin/__init__.pyi
@@ -67,7 +67,10 @@ class AdminClient(_AdminClientImpl):
     def list_topics(self, topic: str | None = None, timeout: float = -1) -> "ClusterMetadata": ...
     def list_groups(self, *args, **kwargs) -> "ListConsumerGroupsResult | None": ...
     def create_partitions(
-        self, new_partitions: list["NewPartitions"], operation_timeout: float = 0, request_timeout: float = 1000.0,
+        self,
+        new_partitions: list["NewPartitions"],
+        operation_timeout: float = 0,
+        request_timeout: float = 1000.0,
         validate_only: bool = False,
     ) -> dict[str, "Future[NewTopic | None]"]: ...
     def describe_configs(


### PR DESCRIPTION
feat: add missing bool to AdminClient create_partitions method
https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/_modules/confluent_kafka/admin.html#AdminClient.create_partitions

⚠️ Noted that the latest version of Confluent Kafka Python is `2.3.x` now.

- For introducing new signatures, please use `feat`
- For fixing compatible signature in `2.2.x`, please use `fix`

### **Description:**

feat: add missing bool to AdminClient create_partitions method
https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/_modules/confluent_kafka/admin.html#AdminClient.create_partitions
2.2.0 reference -> [confluent docs](https://docs.confluent.io/platform/7.4/clients/confluent-kafka-python/html/index.html#confluent_kafka.admin.AdminClient.create_partitions_
### **Related Issue:**

If this pull request is related to an issue, please link it here.

### **Type of change**:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)




### **Additional Details:**

Any additional context, explanation, or reasoning for the changes made.

### **Screenshots:**

If applicable, provide screenshots or images to visually represent the changes.



### **Checklist:**

- [ ] All code follows the project's coding style and conventions.
- [ ] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings or errors.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding updates to the documentation.
