### PR TITLE
fix: use concurrent.future.Future instead of asyncio.Future

### DIFF
--- a/confluent_kafka-stubs/admin/__init__.pyi
+++ b/confluent_kafka-stubs/admin/__init__.pyi
@@ -5,7 +5,7 @@ This package is licensed under the Apache 2.0 License.
 from __future__ import annotations
 
 # standard library
-from asyncio import Future
+from concurrent.futures import Future
 from typing import Any
 
 from .._model import ConsumerGroupState, ConsumerGroupTopicPartitions


### PR DESCRIPTION
⚠️ Noted that the latest version of Confluent Kafka Python is `2.3.x` now.

- For introducing new signatures, please use `feat`
- For fixing compatible signature in `2.2.x`, please use `fix`

### **Description:**

Switch from `asyncio.Future `to  `concurrent.futures import Future`.



### **Related Issue:**

Closes #197 



### **Type of change**:

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)


### **Additional Details:**

Any additional context, explanation, or reasoning for the changes made.



### **Screenshots:**

If applicable, provide screenshots or images to visually represent the changes.



### **Checklist:**

- [x] All code follows the project's coding style and conventions.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or errors.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding updates to the documentation.
