### PR TITLE
ci(workflow): diable ruff F821, F822

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ exclude = [
     "tests",
 ]
 
+[tool.ruff.lint]
+ignore = ["F821", "F822"]
+
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"


### PR DESCRIPTION
⚠️ Please make sure:
  - [ ] Your branch name pattern is `{type}/confluent-kafka-{version}`. For example, `feat/confluent-kafka-2.2.x/introduce_new_signatures`.
  - [ ] Type prefix - for introducing **A NEW FILE**, please use `feat` or `feature`
  - [ ] Type prefix - For introducing **A NEW SIGNATURE**, please use `refactor` or `enhancement` or `enh`
  - [ ] Type prefix - For fixing compatible signature in `2.2.x`, please use `fix`
  - [ ] If it's backporting, please manually add the confluent-kafka version labels.

---

### **Description:**
This pull request includes a small change to the `pyproject.toml` file. The change adds specific linting rules to ignore certain error codes.

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R75-R77): Added `ignore = ["F821", "F822"]` to the `[tool.ruff.lint]` section to exclude specific linting errors.


### **Type of change**:

Please delete options that are not relevant.
- [x] Other minor changes (workflow, GitHub configs, etc.)


### **Additional Details:**

Any additional context, explanation, or reasoning for the changes made.


### **Screenshots:**

If applicable, provide screenshots or images to visually represent the changes.


### **Checklist:**

- [x] All code follows the project's coding style and conventions.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or errors.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding updates to the documentation.
