### PR TITLE
ci(workflow): add pr target on to allow forked repo use labeler

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,8 @@ Please make sure to fill in the details, check the boxes and select the correspo
   - [ ] Type prefix - For introducing **A NEW SIGNATURE**, please use `refactor` or `enhancement` or `enh`
   - [ ] Type prefix - For fixing compatible signature in `2.2.x`, please use `fix`
   - [ ] If it's backporting, please manually add the confluent-kafka version labels.
+  - [ ] If it's a workflow change, please use `workflow` or `ci` as the type prefix.
+  - [ ] If it's a documentation change, please use `docs` as the type prefix.
 
 ---
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  pull_request_target:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION

### **Description:**
This pull request includes a small change to the GitHub Actions workflow configuration in the `.github/workflows/pull-request.yml` file. The change introduces a new event trigger for `pull_request_target` to the existing workflow.

* [`.github/workflows/pull-request.yml`](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0R7-R9): Added `pull_request_target` event trigger for the `main` branch.


### **Type of change**:
- [x] Other minor changes (workflow, GitHub configs, etc.)

### **Checklist:**

- [x] All code follows the project's coding style and conventions.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or errors.
- [x\  I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding updates to the documentation.
