### PR TITLE
fix: add TopicPartition.error

### DIFF
--- a/confluent_kafka-stubs/cimpl.pyi
+++ b/confluent_kafka-stubs/cimpl.pyi
@@ -369,6 +369,7 @@ class TopicPartition:
     offset: ClassVar[int]
     metadata: ClassVar[str | None]
     leader_epoch: ClassVar[int | None]
+    error: ClassVar[KafkaError | None]
 
     def __init__(
         self,


### PR DESCRIPTION
### **Description:**

Added `TopicPartition.error`, documented here: https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#confluent_kafka.TopicPartition.error


### **Related Issue:**

https://github.com/benbenbang/types-confluent-kafka/issues/234



### **Type of change**:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


### **Checklist:**

- [x] All code follows the project's coding style and conventions.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or errors.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding updates to the documentation.
