### PR TITLE
fix: add callback as original parameter for produce alias on_delivery

### DIFF
--- a/confluent_kafka-stubs/avro/__init__.pyi
+++ b/confluent_kafka-stubs/avro/__init__.pyi
@@ -35,7 +35,8 @@ class AvroProducer(Producer):
         value: str | bytes | None = None,
         key: str | bytes | None = None,
         partition: int | None = None,
-        on_delivery: Callable | None = None,
+        callback: Callable | None = None,
+        on_delivery: Callable | None = None, # Alias
         timestamp: int = 0,
         headers: dict[str, str | bytes] | list[tuple[str, str | bytes]] | None = None,
     ) -> None: ...

--- a/confluent_kafka-stubs/cimpl.pyi
+++ b/confluent_kafka-stubs/cimpl.pyi
@@ -433,7 +433,8 @@ class Producer:
         value: str | bytes | None = None,
         key: str | bytes | None = None,
         partition: int | None = None,
-        on_delivery: Callable[[KafkaError | None, Message], None] | None = None,
+        callback: Callable[[KafkaError | None, Message], None] | None = None,
+        on_delivery: Callable[[KafkaError | None, Message], None] | None = None, # Alias
         timestamp: int = 0,
         headers: dict[str, str | bytes] | list[tuple[str, str | bytes]] | None = None,
     ) -> None: ...

--- a/confluent_kafka-stubs/serializing_producer.pyi
+++ b/confluent_kafka-stubs/serializing_producer.pyi
@@ -23,7 +23,8 @@ class SerializingProducer(_ProducerImpl):
         key: object | None = None,
         value: object | None = None,
         partition: int = -1,  # type: ignore[override]
-        on_delivery: Callable[[KafkaError | None, Message], None] | None = None,
+        callback: Callable[[KafkaError | None, Message], None] | None = None,
+        on_delivery: Callable[[KafkaError | None, Message], None] | None = None, # Alias
         timestamp: float = 0,
         headers: dict[str, bytes | None] | None = None,  # type: ignore[override]
     ) -> None: ...


### PR DESCRIPTION
⚠️ Please make sure:
  - [x] Your branch name pattern is `{type}/confluent-kafka-{version}`. For example, `feat/confluent-kafka-2.2.x/introduce_new_signatures`.
  - [x] Type prefix - for introducing **A NEW FILE**, please use `feat` or `feature`
  - [x] Type prefix - For introducing **A NEW SIGNATURE**, please use `refactor` or `enhancement` or `enh`
  - [x] Type prefix - For fixing compatible signature in `2.2.x`, please use `fix`
  - [x] If it's backporting, please manually add the confluent-kafka version labels.

---

### **Description:**

`on_delivery`, one of the current parameters of `Producer.produce`, is an alias for `callback` which is missing, since almost the beginning like `confluent-kafka-0.9.12`.

https://github.com/confluentinc/confluent-kafka-python/blob/v0.9.1.2/confluent_kafka/src/Producer.c#L252-L253

https://github.com/confluentinc/confluent-kafka-python/blob/v0.9.1.2/confluent_kafka/src/Producer.c#L367-L368

https://github.com/confluentinc/confluent-kafka-python/commit/6d90fa726a81f68d324d14da1f77103b46c51a05#diff-60b27e7323e9765c71d52efdd6914856b0a776f327f1c6e51c64f8564644faaa




### **Related Issue:**

N/A



### **Type of change**:

Please delete options that are not relevant.

- [x] New feature / Refactor / Enhancement (non-breaking change which adds new typings)


### **Additional Details:**

https://github.com/confluentinc/confluent-kafka-python/blob/v2.10.1/README.md?plain=1#L58

https://github.com/confluentinc/confluent-kafka-python/blob/v2.10.1/docs/index.rst?plain=1#L1064-L1065

https://github.com/confluentinc/confluent-kafka-python/blob/v2.10.1/examples/producer.py#L55

https://github.com/confluentinc/confluent-kafka-python/blob/v2.10.1/examples/confluent_cloud.py#L98-L99

https://github.com/confluentinc/confluent-kafka-python/blob/v2.10.1/examples/fips/fips_producer.py#L69

https://github.com/confluentinc/confluent-kafka-python/blob/v2.10.1/tests/test_Producer.py#L37-L38

https://github.com/confluentinc/confluent-kafka-python/blob/v2.10.1/tests/test_Producer.py#L262

https://github.com/confluentinc/confluent-kafka-python/blob/v2.10.1/tests/test_threads.py#L24

https://github.com/confluentinc/confluent-kafka-python/blob/v2.10.1/tests/integration/integration_test.py#L183-L186

https://github.com/confluentinc/confluent-kafka-python/blob/v2.10.1/tests/integration/integration_test.py#L198-L199

https://github.com/confluentinc/confluent-kafka-python/blob/v2.10.1/tests/integration/integration_test.py#L313


### **Screenshots:**

N/A


### **Checklist:**

- [x] All code follows the project's coding style and conventions.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or errors.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding updates to the documentation.

---