### PR TITLE
Fix/pre commit

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: install dependencies
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     branches:
       - main
+    types:
+      - edited
+      - reopened
+      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -11,66 +15,12 @@ concurrency:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/${{ github.repository }}/pre-commit:py3.11
-      options: -w ${{ github.workspace }}
-      volumes:
-        - ${{ github.workspace }}:${{ github.workspace }}
+    uses: benbenbang/r-workflows/.github/workflows/pre-commit.yml@main
     permissions:
+      packages: read
       contents: read
       pull-requests: read
-      packages: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: configure git
-        run: |
-          git config --global --add safe.directory $GITHUB_WORKSPACE
-          git config --global credential.helper store
-      - name: cache pre-commit hooks
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pre-commit
-          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
-      - run: |
-          # fetch origin default branch
-          git fetch origin --depth 10 ${{ github.event.repository.default_branch }}:${{ github.event.repository.default_branch }} || true
-
-          #  install pre-commit hooks and run tests
-          pre-commit install && pre-commit install --hook commit-msg
-          pre-commit run --files $(git diff --name-only ${{ github.event.repository.default_branch }}..HEAD)
-
-  pr-title-check:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/${{ github.repository }}/pre-commit:py3.11
-      options: -w ${{ github.workspace }}
-      volumes:
-        - ${{ github.workspace }}:${{ github.workspace }}
-    permissions:
-      contents: read
-      pull-requests: read
-      packages: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Prepare testing environment
-        run: |
-          # configure git
-          git config --global --add safe.directory $GITHUB_WORKSPACE
-          git config --global credential.helper store
-          git config --global user.email "ptah@github.com"
-          git config --global user.name "ptah-lgtm"
-
-          # install pre-commit hooks
-          pre-commit install && pre-commit install --hook commit-msg
-      - name: Check title with dummy commit message
-        run: |
-          echo "checking PR title: '${{ github.event.pull_request.title }}'"
-          git commit --allow-empty -m "${{ github.event.pull_request.title }}"
+    secrets: inherit
 
   pr-labeler:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 default_language_version:
   python: python3
 
-default_stages: [commit]
+default_stages: [pre-commit]
 
 repos:
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
       - id: isort
         name: isort
@@ -13,7 +13,7 @@ repos:
         args:
           - "--settings-path=.isort.cfg"
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.12.2
     hooks:
       - id: ruff
         args: [--fix]

--- a/confluent_kafka-stubs/avro/__init__.pyi
+++ b/confluent_kafka-stubs/avro/__init__.pyi
@@ -36,7 +36,7 @@ class AvroProducer(Producer):
         key: str | bytes | None = None,
         partition: int | None = None,
         callback: Callable | None = None,
-        on_delivery: Callable | None = None, # Alias
+        on_delivery: Callable | None = None,  # Alias
         timestamp: int = 0,
         headers: dict[str, str | bytes] | list[tuple[str, str | bytes]] | None = None,
     ) -> None: ...

--- a/confluent_kafka-stubs/cimpl.pyi
+++ b/confluent_kafka-stubs/cimpl.pyi
@@ -434,7 +434,7 @@ class Producer:
         key: str | bytes | None = None,
         partition: int | None = None,
         callback: Callable[[KafkaError | None, Message], None] | None = None,
-        on_delivery: Callable[[KafkaError | None, Message], None] | None = None, # Alias
+        on_delivery: Callable[[KafkaError | None, Message], None] | None = None,  # Alias
         timestamp: int = 0,
         headers: dict[str, str | bytes] | list[tuple[str, str | bytes]] | None = None,
     ) -> None: ...

--- a/confluent_kafka-stubs/serializing_producer.pyi
+++ b/confluent_kafka-stubs/serializing_producer.pyi
@@ -24,7 +24,7 @@ class SerializingProducer(_ProducerImpl):
         value: object | None = None,
         partition: int = -1,  # type: ignore[override]
         callback: Callable[[KafkaError | None, Message], None] | None = None,
-        on_delivery: Callable[[KafkaError | None, Message], None] | None = None, # Alias
+        on_delivery: Callable[[KafkaError | None, Message], None] | None = None,  # Alias
         timestamp: float = 0,
         headers: dict[str, bytes | None] | None = None,  # type: ignore[override]
     ) -> None: ...


### PR DESCRIPTION
This pull request includes updates to GitHub Actions workflows and pre-commit configurations to improve automation and dependency management. The most important changes involve upgrading GitHub Actions versions, simplifying workflow definitions, and updating pre-commit hooks to newer versions.

### GitHub Actions workflow updates:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L18-R20): Upgraded `actions/setup-python` from version `v2` to `v5` and updated the Python version from `3.10` to `3.13` for better compatibility and access to newer features.
* [`.github/workflows/pull-request.yml`](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0R7-R23): Simplified the workflow by replacing custom steps for pre-commit checks with a reusable workflow (`benbenbang/r-workflows/.github/workflows/pre-commit.yml@main`). Added new `types` (`edited`, `reopened`, `synchronize`) under `pull_request_target` to expand trigger conditions. Removed redundant steps and permissions for pre-commit and PR title checks.

### Pre-commit configuration updates:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L4-R16): Changed `default_stages` from `[commit]` to `[pre-commit]` for better alignment with pre-commit usage. Upgraded `isort` from version `5.13.2` to `6.0.1` and `ruff` from version `v0.6.9` to `v0.12.2` to leverage improvements and bug fixes in newer versions.