### PR TITLE
ci(workflow): introduce 3.12, 3.13 to main branch's matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         test-type: ["mypy", "pyright"]
         os: ["ubuntu-latest"]
         arch: ["x64", "arm64"] # "arm64" temp switch off, too many trouble with it

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
           pipx run uv sync --all-groups
           pip freeze
         env:
-          poetry_version: "1.5.1"
+          uv_version: "0.7.19"
 
       - name: extract tag name
         run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for testing and publishing. The most important changes include extending Python version support in the testing matrix and updating environment variables in the publishing workflow.

### Updates to testing workflow:
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L48-R48): Added support for Python versions `3.12` and `3.13` in the testing matrix.

### Updates to publishing workflow:
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L30-R30): Replaced the `poetry_version` environment variable with `uv_version` set to `0.7.19`.