### PR TITLE
ci(workflow): suppress instrumented tooling from uv to build pkg

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           echo "build with release version: ${TAG_NAME}"
           pipx run uv version ${TAG_NAME} || echo "toml is already up to date."
-          pipx run uv build
+          pipx run uv build --no-sources
 
       - name: publish to pypi
         env:

--- a/.github/workflows/publishrc.yml
+++ b/.github/workflows/publishrc.yml
@@ -69,7 +69,7 @@ jobs:
           fi
           echo "build with release candidate version: ${TAG_NAME}"
           uv version ${TAG_NAME}
-          uv build
+          uv build --no-sources
         env:
           TAG_NAME: ${{ github.event.inputs.tagName }}
           COMMIT_SHA: ${{ github.event.inputs.commitSha }}

--- a/.github/workflows/release-cp.yml
+++ b/.github/workflows/release-cp.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           echo "build with release version: ${TAG_NAME}"
           uv version ${TAG_NAME} || echo "toml is already up to date."
-          uv build
+          uv build --no-sources
       - name: publish to pypi
         env:
           PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/release-cp.yml
+++ b/.github/workflows/release-cp.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: show dependencies
         run: |
           pip list

--- a/.github/workflows/release-cp.yml
+++ b/.github/workflows/release-cp.yml
@@ -49,7 +49,7 @@ jobs:
     name: publish
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository }}/pre-commit:py3.11
+      image: ghcr.io/${{ github.repository }}/pre-commit:py3.12
       options: -w ${{ github.workspace }}
       volumes:
         - ${{ github.workspace }}:${{ github.workspace }}


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to improve compatibility and streamline the build process. Key changes include upgrading Python versions, modifying container images, and adding the `--no-sources` flag to `uv build` commands.

### Workflow Updates for Python Compatibility:
* [`.github/workflows/release-cp.yml`](diffhunk://#diff-fd96c6cb4d9ffec6ca4a96d44bb6ca11d54b1d8f5418dce91fdbb4487b224ba4L52-R52): Updated the container image to use Python 3.12 (`ghcr.io/${{ github.repository }}/pre-commit:py3.12`) and changed the Python setup to version 3.12. [[1]](diffhunk://#diff-fd96c6cb4d9ffec6ca4a96d44bb6ca11d54b1d8f5418dce91fdbb4487b224ba4L52-R52) [[2]](diffhunk://#diff-fd96c6cb4d9ffec6ca4a96d44bb6ca11d54b1d8f5418dce91fdbb4487b224ba4L63-R63)

### Build Process Improvements:
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L39-R39): Added the `--no-sources` flag to the `uv build` command to streamline the build process.
* [`.github/workflows/publishrc.yml`](diffhunk://#diff-2c82397e37f2eef117427f61fef543283d0bd605afa310298cc2a949d6b9ba55L72-R72): Added the `--no-sources` flag to the `uv build` command for release candidates.
* [`.github/workflows/release-cp.yml`](diffhunk://#diff-fd96c6cb4d9ffec6ca4a96d44bb6ca11d54b1d8f5418dce91fdbb4487b224ba4L73-R73): Added the `--no-sources` flag to the `uv build` command for release builds.