### PR TITLE
fix(workflow): drop ref condition in pr target mode

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,7 +44,6 @@ jobs:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: fetch origin
-        if: ${{ github.ref != 'refs/heads/main' }}
         run: |
           # fetch origin default branch
           git fetch --all || echo "unable to fetch all"


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/pull-request.yml` file. The conditional check for the `fetch origin` step was removed, ensuring the step always runs regardless of the branch being processed.