### PR TITLE
refactor(avro): add missing default value for CachedSchemaRegistryClient

### DIFF
--- a/confluent_kafka-stubs/avro/cached_schema_registry_client.pyi
+++ b/confluent_kafka-stubs/avro/cached_schema_registry_client.pyi
@@ -38,7 +38,7 @@ class CachedSchemaRegistryClient:
     def __init__(
         self,
         url: str | dict,
-        max_schemas_per_subject: int,
+        max_schemas_per_subject: int = 1000,
         ca_location: str | Path | None = None,
         cert_location: str | Path | None = None,
         key_location: str | Path | None = None,


### PR DESCRIPTION
This pull request introduces a default value for the `max_schemas_per_subject` parameter in the `CachedSchemaRegistryClient` class constructor. The change enhances usability by eliminating the need to explicitly specify this parameter in most cases.

* [`confluent_kafka-stubs/avro/cached_schema_registry_client.pyi`](diffhunk://#diff-42e6f1f78a3cc4e7338e7ce6365bb20a78fd676378e55579e8a24be502824f51L41-R41): Added a default value of `1000` to the `max_schemas_per_subject` parameter in the `__init__` method of the `CachedSchemaRegistryClient` class.

resolve #208 