### PR TITLE
ci(workflows): drop reusable pre-commit

### DIFF
--- a/.github/workflows/pull-request-target.yml
+++ b/.github/workflows/pull-request-target.yml
@@ -11,7 +11,7 @@ on:
       - synchronize
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-labeler
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-target
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,8 +17,45 @@ concurrency:
 jobs:
   pre-commit:
     name: pre-commit checks
-    uses: benbenbang/r-workflows/.github/workflows/pre-commit.yml@main
-    secrets: inherit
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      actions: write
+      contents: read
+      statuses: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: prepare test environment
+        run: |
+          pipx install pre-commit
+          pre-commit install && pre-commit install --hook commit-msg
+          git config --global user.email "pr-title-check@github.com"
+          git config --global user.name "pr-title-validator"
+      - name: cache pre-commit hooks
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: fetch origin
+        run: |
+          # fetch origin default branch
+          git fetch --all || echo "unable to fetch all"
+          git fetch origin ${{ github.event.repository.default_branch }} || echo "unable to fetch origin"
+          git fetch origin --depth 10 ${{ github.event.repository.default_branch }}:${{ github.event.repository.default_branch }} || true
+      - name: run pre-commit on pull request (changed files)
+        run: |
+          # run pre-commit on all files or specific files
+          if [[ "${RUN_ALL_FILES}" == "true" ]]; then
+            pre-commit run --all-files
+          else
+            pre-commit run --files $(git diff --name-only origin/${{ github.event.repository.default_branch }}..HEAD)
+          fi
+      - name: check pr title
+        run: |
+          echo "checking PR title: '${{ github.event.pull_request.title }}'"
+          git commit --allow-empty -m "${{ github.event.pull_request.title }}"
 
   pr-check-change-files:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request makes changes to GitHub Actions workflows to improve concurrency handling and enhance pre-commit checks. The most important updates include modifying the concurrency group in `.github/workflows/pull-request-target.yml` and replacing the pre-commit workflow in `.github/workflows/pull-request.yml` with a detailed setup and execution process.

### Workflow concurrency improvements:
* [`.github/workflows/pull-request-target.yml`](diffhunk://#diff-ef5ba6d24a13fb62d98bd915d166833f97a83f114f26af945e8d0939e26ec140L14-R14): Updated the `concurrency` group to use `target` instead of `labeler`, ensuring more accurate grouping for pull request events.

### Pre-commit checks enhancement:
* [`.github/workflows/pull-request.yml`](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0L20-R58): Replaced the `pre-commit` job with a custom setup that installs pre-commit hooks, caches them, fetches the default branch, and runs pre-commit checks on changed files or all files. Added permissions and environment preparation steps for better control and reliability.