### PR TITLE
build(config): update project metadata and configs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "types-confluent-kafka"
 version = "1.3.5"
 description = "Types for Confluent Kafka"
 readme = "README.md"
+license = "Apache-2.0"
 license-files = ["LICENSE"]
 keywords = [
     "types",
@@ -18,7 +19,6 @@ keywords = [
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.9",
@@ -46,6 +46,13 @@ lint = [
 ]
 publish = ["twine>=6.1.0"]
 
+[project.urls]
+Homepage = "https://github.com/benbenbang/types-confluent-kafka"
+Documentation = "https://readthedocs.org"
+Repository = "https://github.com/benbenbang/types-confluent-kafka.git"
+Issues = "https://github.com/benbenbang/types-confluent-kafka/issues"
+Changelog = "https://github.com/benbenbang/types-confluent-kafka/releases"
+
 [tool.ruff]
 line-length = 120
 indent-width = 4
@@ -54,6 +61,7 @@ exclude = [
     ".venv",
     ".cache",
     ".mypy_cache",
+    ".ruff_cache",
     ".env",
     "build",
     "dist",
@@ -95,3 +103,6 @@ stubPath = "confluent_kafka-stubs"
 reportMissingImports = "warning"
 reportIncompatibleMethodOverride = "none"
 reportAttributeAccessIssue = "none"
+
+venvPath = "."
+venv = ".venv"


### PR DESCRIPTION
This pull request updates the `pyproject.toml` file to enhance metadata, improve project configuration, and refine tooling settings. The most important changes include adding a license field, updating project URLs, refining the exclusion list for tools, and specifying virtual environment settings.

### Metadata enhancements:
* Added `license = "Apache-2.0"` to explicitly define the project's license.
* Added a `[project.urls]` section with links to the homepage, documentation, repository, issues, and changelog for better project discoverability.

### Tooling configuration:
* Updated the exclusion list by adding `.ruff_cache` to ensure the cache directory is ignored by tooling.
* Added `venvPath` and `venv` settings to specify the virtual environment path and name.