### PR TITLE
fix(workflows): remove non exist inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,4 @@ jobs:
     uses: benbenbang/types-confluent-kafka/.github/workflows/semantic-release.yml@workflows
     secrets: inherit
     with:
-      python_version: "3.12"
-      uv_version: "0.7.19"
       dry_run: false


### PR DESCRIPTION
This pull request makes a minor adjustment to the `.github/workflows/release.yml` file. It removes the `python_version` and `uv_version` parameters from the `jobs` configuration.