### PR TITLE
build(config): update project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ publish = ["twine>=6.1.0"]
 
 [project.urls]
 Homepage = "https://github.com/benbenbang/types-confluent-kafka"
-Documentation = "https://readthedocs.org"
+Documentation = "https://benbenbang.github.io/types-confluent-kafka/"
 Repository = "https://github.com/benbenbang/types-confluent-kafka.git"
 Issues = "https://github.com/benbenbang/types-confluent-kafka/issues"
 Changelog = "https://github.com/benbenbang/types-confluent-kafka/releases"


### PR DESCRIPTION
This pull request updates the documentation URL in the `pyproject.toml` file to point to a new location.

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L59-R59): Changed the `Documentation` URL from "https://readthedocs.org" to "https://benbenbang.github.io/types-confluent-kafka/" to reflect the updated hosting for the project's documentation.