### PR TITLE
refactor: update python version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.9,<=3.13"
+requires-python = ">=3.9,<3.14"
 dependencies = []
 
 [dependency-groups]
@@ -48,10 +48,7 @@ docs = [
     "mkdocs-simple-hooks>=0.1.5",
     "mkdocstrings-python>=1.16.12",
 ]
-lint = [
-    "pre-commit>=4.2.0",
-    "ruff>=0.12.2",
-]
+lint = ["pre-commit>=4.2.0", "ruff>=0.12.2"]
 publish = ["twine>=6.1.0"]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.9, <=3.13"
+requires-python = ">=3.9, <3.14"
 resolution-markers = [
     "python_full_version >= '3.10'",
     "python_full_version < '3.10'",


### PR DESCRIPTION
This pull request includes updates to the `pyproject.toml` file, focusing on adjusting Python version constraints and reformatting the `lint` dependency list for consistency.

### Configuration updates:

* Updated the `requires-python` field to allow Python versions `<3.14` instead of `<=3.13`, ensuring compatibility with future Python releases. (`pyproject.toml`, [pyproject.tomlL33-R33](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L33-R33))

### Formatting improvements:

* Reformatted the `lint` dependency list from a multi-line format to a single-line format for consistency with other dependency groups. (`pyproject.toml`, [pyproject.tomlL51-R51](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L51-R51))