### PR TITLE
fix: update workflows inputs

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -45,7 +45,7 @@ jobs:
       - name: set python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python_version: ${{ github.event.inputs.python_version }}
 
       - name: install dependencies
         run: |
@@ -55,7 +55,7 @@ jobs:
           uv sync --all-groups
           pip list
         env:
-          uv_version: "0.7.19"
+          uv_version: ${{ github.event.inputs.uv_version }}
 
       - name: update project version by git tag
         run: |


### PR DESCRIPTION
This pull request updates the `.github/workflows/versioning.yml` file to make the workflow more dynamic by using input variables for Python and `uv` versions. This change allows greater flexibility when triggering the workflow.

Key changes:

### Workflow Parameterization:
* Updated the `python-version` in the `set python` step to use the `github.event.inputs.python_version` variable instead of a hardcoded value (`3.12`).
* Updated the `uv_version` environment variable in the `install dependencies` step to use the `github.event.inputs.uv_version` variable instead of a hardcoded value (`0.7.19`).