### PR TITLE
fix(workflows): release workflow missing permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ permissions:
   issues: write
   pull-requests: write
   id-token: write
+  packages: read
 
 jobs:
   release:


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration in `.github/workflows/release.yml`. It updates the `permissions` section to include `packages: read`, allowing the workflow to read package data.