### PR TITLE
ci(workflows): enhance automation and keeping track uv.lock

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -71,3 +71,19 @@ jobs:
         run: |
           uv run pyright --version
           uv run pyright confluent_kafka-stubs
+
+  workflow-success:
+    needs: [pre-commit, pr-check-change-files, typing-tests]
+    if: |
+      always() && ${{ needs.pre-commit.result == 'success' }} &&
+      ${{ needs.pr-check-change-files.result == 'success' }} &&
+      (
+        ${{ needs.typing-tests.result == 'success' }} ||
+        ${{ needs.typing-tests.result == 'skipped' }}
+      )
+    name: workflow success
+    runs-on: ubuntu-latest
+    steps:
+      - name: success
+        run: |
+          echo "🎉 all tests passed"

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -76,7 +76,8 @@ jobs:
 
           # clean up artifacts before update pyproject.toml
           git clean -f -x || echo "nothing to remove"
-          git rm node_modules || echo "no node modules to remove"
+          git reset --hard HEAD || true
+          echo "all cleaned up"
 
           # make sure up to date
           git pull --rebase origin main
@@ -92,7 +93,7 @@ jobs:
             git checkout -b "${branch_name}"
 
             # commit and create pr
-            git add pyproject.toml
+            git add pyproject.toml uv.lock
             git commit -m "chore(${next_tag_modified}): update version to $next_tag"
             git remote set-url origin https://x-access-token:${{ steps.generate_token.outputs.token }}@github.com/${GITHUB_REPOSITORY}.git
             git push -f origin "${branch_name}"
@@ -100,7 +101,8 @@ jobs:
               --title "release(versioning): update version to $next_tag" \
               --body "Automated PR to bump the version pre-release." \
               --label "release" \
-              --reviewer "benbenbang"
+              --reviewer "benbenbang" \
+              --reviewer "ptah-lgtm"
 
           else
             echo "nothing to commit!"

--- a/uv.lock
+++ b/uv.lock
@@ -1376,7 +1376,7 @@ wheels = [
 
 [[package]]
 name = "types-confluent-kafka"
-version = "1.3.5"
+version = "1.3.6"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
This pull request updates the `.github/workflows/versioning.yml` file to improve the versioning workflow by refining cleanup steps, ensuring all necessary files are committed, and adding an additional reviewer for pull requests.

### Workflow improvements:

* Replaced the `git rm node_modules` command with `git reset --hard HEAD` for a more robust cleanup process and added a confirmation message "all cleaned up." (`[.github/workflows/versioning.ymlL79-R80](diffhunk://#diff-a939aacba1dba4141eda9eda616ff5e54462b324fbaebe0f8848c06964e67c68L79-R80)`)
* Updated the `git add` command to include `uv.lock` alongside `pyproject.toml`, ensuring all relevant files are staged for version updates. (`[.github/workflows/versioning.ymlL95-R105](diffhunk://#diff-a939aacba1dba4141eda9eda616ff5e54462b324fbaebe0f8848c06964e67c68L95-R105)`)

### Pull request process enhancements:

* Added an additional reviewer (`ptah-lgtm`) to the list of reviewers for automated pull requests, improving the review process. (`[.github/workflows/versioning.ymlL95-R105](diffhunk://#diff-a939aacba1dba4141eda9eda616ff5e54462b324fbaebe0f8848c06964e67c68L95-R105)`)