### PR TITLE
ci(workflows): enhance release branch

### DIFF
--- a/.github/workflows/release-cp.yml
+++ b/.github/workflows/release-cp.yml
@@ -1,11 +1,12 @@
 name: release
 
 on:
-  push:
-    tags:
-      - \d+\.\d+\.\d+
-    branches:
-      - confluent-kafka-v*
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g., 1.2.3)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -22,13 +23,20 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 50
+          fetch-depth: 0
 
-      - name: extract tag name
+      - name: generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TECHNICAL_APP_APP_ID }}
+          private-key: ${{ secrets.TECHNICAL_APP_PEM }}
+
+      - name: set tag name
         run: |
-          export TAG_NAME=${GITHUB_REF#refs/tags/}
-          echo "Extracted tag name: $TAG_NAME"
-          echo "TAG_NAME=${TAG_NAME} >> $GITHUB_ENV"
+          export TAG_NAME=${{ github.event.inputs.tag }}
+          echo "Using tag: $TAG_NAME"
+          echo "TAG_NAME=${TAG_NAME}" >> $GITHUB_ENV
 
       - name: semantic release
         run: |
@@ -39,11 +47,7 @@ jobs:
                             --latest \
                             $TAG_NAME
         env:
-          GH_TOKEN: ${{ secrets.PTAH_CI_TOKEN }}
-          GIT_AUTHOR_EMAIL: ${{ secrets.GH_GIT_AUTHOR_EMAIL }}
-          GIT_AUTHOR_NAME: ${{ secrets.GH_GIT_AUTHOR_NAME }}
-          GIT_COMMITTER_EMAIL: ${{ secrets.GH_GIT_COMMITTER_EMAIL }}
-          GIT_COMMITTER_NAME: ${{ secrets.GH_GIT_COMMITTER_NAME }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
 
   publish:
     name: publish
@@ -64,8 +68,8 @@ jobs:
       - name: show dependencies
         run: |
           pip list
-      - name: extract tag name
-        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      - name: set tag name
+        run: echo "TAG_NAME=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
       - name: build with uv
         run: |
           echo "build with release version: ${TAG_NAME}"
@@ -81,4 +85,4 @@ jobs:
         run: |
           gh release upload ${TAG_NAME} dist/*
         env:
-          GH_TOKEN: ${{ secrets.PTAH_CI_TOKEN }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/release-cp.yml` file to switch from a tag-based trigger to a manual workflow dispatch with inputs. It also introduces a GitHub App token for authentication and simplifies the handling of release tags. 

### Workflow trigger and input changes:
* Replaced the tag-based trigger with a `workflow_dispatch` trigger, allowing manual execution with a required `tag` input.

### Authentication updates:
* Replaced the use of `PTAH_CI_TOKEN` with a dynamically generated GitHub App token for authentication, using the `actions/create-github-app-token@v1` action. [[1]](diffhunk://#diff-fd96c6cb4d9ffec6ca4a96d44bb6ca11d54b1d8f5418dce91fdbb4487b224ba4L25-R39) [[2]](diffhunk://#diff-fd96c6cb4d9ffec6ca4a96d44bb6ca11d54b1d8f5418dce91fdbb4487b224ba4L42-R50) [[3]](diffhunk://#diff-fd96c6cb4d9ffec6ca4a96d44bb6ca11d54b1d8f5418dce91fdbb4487b224ba4L84-R88)

### Tag handling improvements:
* Updated the process for setting the tag name to use the `tag` input from the workflow dispatch event instead of extracting it from `GITHUB_REF`. [[1]](diffhunk://#diff-fd96c6cb4d9ffec6ca4a96d44bb6ca11d54b1d8f5418dce91fdbb4487b224ba4L25-R39) [[2]](diffhunk://#diff-fd96c6cb4d9ffec6ca4a96d44bb6ca11d54b1d8f5418dce91fdbb4487b224ba4L67-R72)

### Miscellaneous:
* Changed the `fetch-depth` parameter in the `actions/checkout` step from `50` to `0` to fetch the entire history.