### PR TITLE
Fix TopicPartition members

### DIFF
--- a/confluent_kafka-stubs/cimpl.pyi
+++ b/confluent_kafka-stubs/cimpl.pyi
@@ -364,12 +364,12 @@ class NewPartitions:
         def __ne__(self, other: "NewPartitions") -> bool: ...
 
 class TopicPartition:
-    topic: ClassVar[str]
-    partition: ClassVar[int]
-    offset: ClassVar[int]
-    metadata: ClassVar[str | None]
+    topic: str
+    partition: int
+    offset: int
+    metadata: str | None
     leader_epoch: ClassVar[int | None]
-    error: ClassVar[KafkaError | None]
+    error: KafkaError | None
 
     def __init__(
         self,


### PR DESCRIPTION
⚠️ Please make sure:
  - [ ] Your branch name pattern is `{type}/confluent-kafka-{version}`. For example, `feat/confluent-kafka-2.2.x/introduce_new_signatures`.
  - [ ] Type prefix - for introducing **A NEW FILE**, please use `feat` or `feature`
  - [ ] Type prefix - For introducing **A NEW SIGNATURE**, please use `refactor` or `enhancement` or `enh`
  - [x] Type prefix - For fixing compatible signature in `2.2.x`, please use `fix`
  - [ ] If it's backporting, please manually add the confluent-kafka version labels.

---

### **Description:**

Please provide a brief description of the changes made in this pull request.
I had code doing this:

```
tp = confluent_kafka.TopicPartition(topic, p, timestamp)
<...>
if tp.offset == -1:
    tp.offset = confluent_kafka.OFFSET_END
```
Which produces the following mypy error 

```
error: Cannot assign to class variable "offset" via instance  [misc]
```

Looking at the actual implementation

```
In [6]: confluent_kafka.TopicPartition.__dict__
Out[6]:
mappingproxy({'__new__': <function TopicPartition.__new__(*args, **kwargs)>,
              '__repr__': <slot wrapper '__repr__' of 'cimpl.TopicPartition' objects>,
              '__hash__': <slot wrapper '__hash__' of 'cimpl.TopicPartition' objects>,
              '__getattribute__': <slot wrapper '__getattribute__' of 'cimpl.TopicPartition' objects>,
              '__lt__': <slot wrapper '__lt__' of 'cimpl.TopicPartition' objects>,
              '__le__': <slot wrapper '__le__' of 'cimpl.TopicPartition' objects>,
              '__eq__': <slot wrapper '__eq__' of 'cimpl.TopicPartition' objects>,
              '__ne__': <slot wrapper '__ne__' of 'cimpl.TopicPartition' objects>,
              '__gt__': <slot wrapper '__gt__' of 'cimpl.TopicPartition' objects>,
              '__ge__': <slot wrapper '__ge__' of 'cimpl.TopicPartition' objects>,
              '__init__': <slot wrapper '__init__' of 'cimpl.TopicPartition' objects>,
              'topic': <member 'topic' of 'cimpl.TopicPartition' objects>,
              'partition': <member 'partition' of 'cimpl.TopicPartition' objects>,
              'offset': <member 'offset' of 'cimpl.TopicPartition' objects>,
              'metadata': <member 'metadata' of 'cimpl.TopicPartition' objects>,
              'error': <member 'error' of 'cimpl.TopicPartition' objects>,
              'leader_epoch': <attribute 'leader_epoch' of 'cimpl.TopicPartition' objects>,
              '__doc__': 'TopicPartition is a generic type to hold a single partition and various information about it.\n\nIt is typically used to provide a list of topics or partitions for various operations, such as :py:func:`Consumer.assign()`.\n\n.. py:function:: TopicPartition(topic, [partition], [offset], [metadata], [leader_epoch])\n\n  Instantiate a TopicPartition object.\n\n  :param string topic: Topic name\n  :param int partition: Partition id\n  :param int offset: Initial partition offset\n  :param string metadata: Offset metadata\n  :param int leader_epoch: Offset leader epoch\n  :rtype: TopicPartition\n\n\n'})

In [7]:
```



### **Related Issue:**

If this pull request is related to an issue, please link it here.



### **Type of change**:

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


### **Additional Details:**

Any additional context, explanation, or reasoning for the changes made.


### **Screenshots:**

If applicable, provide screenshots or images to visually represent the changes.


### **Checklist:**

- [x] All code follows the project's coding style and conventions.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or errors.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding updates to the documentation.

---

```
‼️ Remove this footer before submitting the PR.
Due to this project is for several different versions of confluent-kafka, we need to make sure the PR is following the correct pattern.
So that the semantic versioning can be maintained and the release process can be done without any issues.
Please make sure to fill in the details, check the boxes and select the corresponding confluence-kafka version label(s).

‼️ PR without the following details will be ignored, and the PR will be closed without any further notice.
```
