### PR TITLE
build: support Python 3.14

### DIFF
--- a/.github/docker/build.sh
+++ b/.github/docker/build.sh
@@ -1,7 +1,7 @@
 #! /bin/env bash
 
 function build_images() {
-    local PYTHON_VERSIONS=(3.9 3.10 3.11 3.12 3.13)
+    local PYTHON_VERSIONS=(3.9 3.10 3.11 3.12 3.13 3.14)
     local UV_VERSION=0.7.19
     local REPOSITORY=benbenbang/types-confluent-kafka
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         test-type: ["mypy", "pyright"]
         os: ["ubuntu-latest"]
         arch: ["x64", "arm64"] # "arm64" temp switch off, too many trouble with it

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         test-type: ["mypy", "pyright"]
         os: ["ubuntu-latest"]
         arch: ["x64", "arm64"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,12 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.9,<3.14"
+requires-python = ">=3.9"
 dependencies = []
 
 [dependency-groups]


### PR DESCRIPTION
### **Description:**

This PR aims to provide official support for Python 3.14, as well as remove the constraints on Python 3.14 that is present in `pyproject.toml`.  
I removed the upper constraint based on this [documentation](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#requires-python-upper-bounds), this is already done on [confluent-kafka side](https://github.com/confluentinc/confluent-kafka-python/blob/master/pyproject.toml#L17).

### **Related Issue:**

https://github.com/benbenbang/types-confluent-kafka/issues/231

https://github.com/confluentinc/confluent-kafka-python/issues/2085

### **Type of change**:

Please delete options that are not relevant.

- [ ] New feature / Refactor / Enhancement (non-breaking change which adds new typings)

### **Checklist:**

- [ ] All code follows the project's coding style and conventions.
- [ ] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings or errors.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding updates to the documentation.
