### PR TITLE
fix: add missing properties to ListOffsetsResultInfo

### DIFF
--- a/confluent_kafka-stubs/admin/_listoffsets.pyi
+++ b/confluent_kafka-stubs/admin/_listoffsets.pyi
@@ -45,4 +45,7 @@ class EarliestSpec(OffsetSpec):
     def _value(self) -> int: ...
 
 class ListOffsetsResultInfo:
+    offset: int
+    timestamp: int
+    leader_epoch: int | None
     def __init__(self, offset: int, timestamp: int, leader_epoch: int | None): ...


### PR DESCRIPTION
### **Description:**

Add missing properties in ListOffsetsResultInfo. First PR to this repo, I'm not sure what "select the corresponding confluence-kafka version label(s)" exactly means, can you help? #14 

I've added 2.5.x because it is the version that was added in these types:
https://github.com/benbenbang/types-confluent-kafka/commit/c880da6579807622d02f95e680d7a0647ecd5fa0

In Confluent repo seems that `ListOffsetsResultInfo` was added in 2.3.0: https://github.com/confluentinc/confluent-kafka-python/commit/aaeca9a6384a8d7b7bc66e97f6c7978d62530936


### **Related Issue:**

https://github.com/benbenbang/types-confluent-kafka/issues/283


### **Type of change**:

Please delete options that are not relevant.

- [ ] New feature / Refactor / Enhancement (non-breaking change which adds new typings)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (Updating or adding documentation, docstrings, etc.)
- [ ] Other minor changes (workflow, GitHub configs, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)


### **Additional Details:**

Any additional context, explanation, or reasoning for the changes made.

Noticed a type error for properties that are part of the class.


### **Screenshots:**

If applicable, provide screenshots or images to visually represent the changes.

<img width="832" height="211" alt="image" src="https://github.com/user-attachments/assets/915a91fe-0dec-4668-9e77-1b08a74c9537" />


### **Checklist:**

- [ ] All code follows the project's coding style and conventions.
- [x] I have performed a self-review of my own code.
- [ ] My changes generate no new warnings or errors.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding updates to the documentation.


