### PR TITLE
docs(readme): add deprecation notice for official type hints support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,15 +16,11 @@
     }
   },
   "features": {
-    "ghcr.io/devcontainers-contrib/features/poetry:2": {
-      "version": "latest"
-    },
-    "ghcr.io/devcontainers-contrib/features/pre-commit:2": {
-      "version": "latest"
-    },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "3.10"
-    }
+    },
+    "ghcr.io/jsburckhardt/devcontainer-features/ruff:1": {},
+    "ghcr.io/jsburckhardt/devcontainer-features/uv:1": {}
   },
   "forwardPorts": [
     3000
@@ -37,7 +33,7 @@
     "source=${localEnv:HOME}/.gnupg,target=/root/.gnupg,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.ssh,target=/root/.ssh,type=bind,consistency=cached"
   ],
-  "name": "react ts devcontainer",
+  "name": "confluent-kafka-stub devcontainer",
   "onCreateCommand": "curl -sS https://starship.rs/install.sh | sh -s -- -y && echo 'source /workspaces/types-confluent-kafka/.devcontainer/bash_profile' >> /root/.bashrc",
   "remoteEnv": {
     "PATH": "${containerEnv:PATH}:/root/.cargo/bin"

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,3 @@
+{
+  "format_on_save": "off"
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # types-confluent-kafka
 
+> [!IMPORTANT]
+> Please make sure you have read this note before using this package or contributing to this project.
+> As of **v2.13.0+**, `confluent-kafka-python` includes official type hints support.
+> Users on **v2.13.0 or above** should prefer the official type hints over this package.
+> This package is intended for users on versions **below v2.13.0**.
+
  [![PyPI version](https://badge.fury.io/py/types-confluent-kafka.svg)](https://badge.fury.io/py/types-confluent-kafka) ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/types-confluent-kafka) [![GitHub issues](https://img.shields.io/github/issues/benbenbang/types-confluent-kafka)](https://github.com/benbenbang/types-confluent-kafka/issues) ![pre-commit enable](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white) [![main](https://github.com/benbenbang/types-confluent-kafka/actions/workflows/main.yml/badge.svg)](https://github.com/benbenbang/types-confluent-kafka/actions/workflows/main.yml) [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://semver.org/)
 
 `types-confluent-kafka` is a package that provides type hints for the `confluent-kafka` Python package. It's designed to enhance your development experience by enabling type checking with tools like `mypy` and providing auto-completion support in your LSP (language server).


### PR DESCRIPTION
This commit updates the project documentation to inform users about official type hints support in newer versions of confluent-kafka-python, modernizes the development container configuration, and adds editor settings. The main changes focus on communicating important information to users and improving the development environment.

**Documentation update:**
* Added a prominent notice in README.md alerting users that Confluent Kafka Python v2.13.0+ now includes official type hints support, recommending users upgrade to the official implementation instead of using this package.

**Development environment improvements:**
* Updated `.devcontainer/devcontainer.json` to replace Poetry and pre-commit features with modern alternatives (ruff and uv), streamlining the development toolchain.
* Changed devcontainer name from "react ts devcontainer" to "confluent-kafka-stub devcontainer" to accurately reflect the project.
* Added `.zed/settings.json` for Zed editor configuration.
